### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/News-Information-Technology/macbook.md
+++ b/News-Information-Technology/macbook.md
@@ -5,7 +5,7 @@
 
 ## 安裝與設定 iTerm2
 
-- http://oomusou.io/osx/iterm2-setup/
+- https://old-oomusou.goodjack.tw/macos/iterm2-setup/
 
 # ifind
 - command+shift+g


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw